### PR TITLE
Update start.go

### DIFF
--- a/runner/start.go
+++ b/runner/start.go
@@ -52,7 +52,7 @@ func liveReload(e string, lr *lrserver.Server) {
 }
 
 func start() {
-	lr, _ := lrserver.New(lrserver.DefaultName, lrserver.DefaultPort)
+	lr := lrserver.New(lrserver.DefaultName, lrserver.DefaultPort)
 	go lr.ListenAndServe()
 	loopIndex := 0
 	buildDelay := buildDelay()


### PR DESCRIPTION
Fixed 'github.com/Nitecon/consul/runner/start.go:55: assignment count mismatch: 2 = 1' issue
lrserver.New() now only returns server, hence removed the unnecessary _